### PR TITLE
Generalize monad to anything that can be locally interpreted in Aff

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,11 +15,11 @@ This component allows you to take any child component and mount it at a target n
 HH.slot _modal unit Modal.component modalInput (Just <<< HandleModal)
 
 -- new: this mounts to the `<body>` node instead
-portal _modal unit Modal.component modalInput Nothing (Just <<< HandleModal)
+portalAff _modal unit Modal.component modalInput Nothing (Just <<< HandleModal)
 ```
 
 The component within the portal can be used exactly as if it were just a regular child component -- you can send queries, subscribe to outputs, and use the component types as before.
 
 ### Limitations
 
-Due to the use of `runUI`, only components which can be run directly in `Aff` are possible to send through a portal. You won't be able to use your custom application monad.
+Due to the use of `runUI`, only components which can be easily interpreted into `Aff` can be used. This includes `Aff` and `ReaderT r Aff`, and that's about it. More specifically, you can provide a function `m (n ~> Aff)` that can pull in the monadic context of the parent to interpret the child component into `Aff`, but effects from the child component will not bubble up to the parent component at all.

--- a/src/Halogen/Portal.purs
+++ b/src/Halogen/Portal.purs
@@ -5,7 +5,9 @@
 module Halogen.Portal where
 
 import Prelude
+
 import Control.Coroutine (consumer)
+import Control.Monad.Reader (ReaderT, asks, runReaderT)
 import Control.Monad.Rec.Class (forever)
 import Data.Coyoneda (unCoyoneda)
 import Data.Foldable (for_)
@@ -21,19 +23,25 @@ import Halogen.VDom.Driver as VDom
 import Web.HTML (HTMLElement)
 import Type.Row as Row
 
-type InputFields query input output
+type InputFields n query input output
   = ( input :: input
-    , child :: H.Component HH.HTML query input output Aff
+    , child :: H.Component HH.HTML query input output n
     , targetElement :: Maybe HTMLElement
     )
 
-type Input query input output
-  = { | InputFields query input output }
+type Input n query input output
+  = { | InputFields n query input output }
 
-type State query input output
+type State n query input output
   = { io :: Maybe (H.HalogenIO query output Aff)
-    | InputFields query input output
+    | InputFields n query input output
     }
+
+newtype NT m n = NT (forall a. m a -> n a)
+ntIdentity :: forall m. NT m m
+ntIdentity = NT identity
+ntReaderT :: forall r m. Monad m => ReaderT r m (NT (ReaderT r m) m)
+ntReaderT = asks \r -> NT \ma -> runReaderT ma r
 
 -- | An alternative to `slot` which mounts the child component to a specific
 -- | HTMLElement in the DOM instead of within the parent component. Use this
@@ -44,15 +52,38 @@ type State query input output
 -- | ```purs
 -- | -- if `Nothing` is provided as the target HTMLElement, then the `<body>`
 -- | -- tag will be used
--- | HH.div_ 
--- |   [ portal _modal unit Modal.component modalInput (Just element) handler ]
+-- | HH.div_
+-- |   [ portal ntIdentity _modal unit Modal.component modalInput (Just element) handler ]
 -- |
--- | -- for comparison, this is how you would mount the component _not_ via 
+-- | -- for comparison, this is how you would mount the component _not_ via
 -- | -- a portal
 -- | HH.div_
 -- |   [ HH.slot _modal unit Modal.component modalInput handler ]
 -- | ```
 portal ::
+  forall query action input output slots label slot _1 m n.
+  Row.Cons label (H.Slot query output slot) _1 slots =>
+  IsSymbol label =>
+  Ord slot =>
+  MonadAff m =>
+  m (NT n Aff) ->
+  SProxy label ->
+  slot ->
+  H.Component HH.HTML query input output n ->
+  input ->
+  Maybe HTMLElement ->
+  (output -> Maybe action) ->
+  H.ComponentHTML action slots m
+portal contextualize label slot childComponent childInput htmlElement handler =
+  handler
+    # HH.slot label slot (component contextualize)
+        { child: childComponent
+        , input: childInput
+        , targetElement: htmlElement
+        }
+
+-- | Run a portal component that is already in `Aff`.
+portalAff ::
   forall query action input output slots label slot _1.
   Row.Cons label (H.Slot query output slot) _1 slots =>
   IsSymbol label =>
@@ -64,26 +95,36 @@ portal ::
   Maybe HTMLElement ->
   (output -> Maybe action) ->
   H.ComponentHTML action slots Aff
-portal label slot childComponent childInput htmlElement handler =
-  handler
-    # HH.slot label slot component
-        { child: childComponent
-        , input: childInput
-        , targetElement: htmlElement
-        }
+portalAff = portal (pure ntIdentity)
+
+-- | Run a portal component that is in `ReaderT r Aff` (for some context `r`).
+portalReaderT ::
+  forall r query action input output slots label slot _1.
+  Row.Cons label (H.Slot query output slot) _1 slots =>
+  IsSymbol label =>
+  Ord slot =>
+  SProxy label ->
+  slot ->
+  H.Component HH.HTML query input output (ReaderT r Aff) ->
+  input ->
+  Maybe HTMLElement ->
+  (output -> Maybe action) ->
+  H.ComponentHTML action slots (ReaderT r Aff)
+portalReaderT = portal ntReaderT
 
 component ::
-  forall query input output m.
+  forall query input output m n.
   MonadAff m =>
-  H.Component HH.HTML query (Input query input output) output m
-component =
+  m (NT n Aff) ->
+  H.Component HH.HTML query (Input n query input output) output m
+component contextualize =
   H.mkComponent
     { initialState
     , render
     , eval
     }
   where
-  initialState :: Input query input output -> State query input output
+  initialState :: Input n query input output -> State n query input output
   initialState { input, child, targetElement } =
     { input
     , child
@@ -92,10 +133,11 @@ component =
     }
 
   eval ::
-    H.HalogenQ query output (Input query input output)
-      ~> H.HalogenM (State query input output) output () output m
+    H.HalogenQ query output (Input n query input output)
+      ~> H.HalogenM (State n query input output) output () output m
   eval = case _ of
     H.Initialize a -> do
+      NT context <- H.lift contextualize
       state <- H.get
       -- Create a blocking mutable variable which will be updated with messages
       -- as they come in.
@@ -104,8 +146,8 @@ component =
       -- document body. Either way, we'll run the sub-tree at the target and
       -- save the resulting interface.
       target <- maybe (H.liftAff awaitBody) pure state.targetElement
-      io <- H.liftAff $ VDom.runUI state.child state.input target
-      -- Subscribe to the child component's messages, writing them to the 
+      io <- H.liftAff $ VDom.runUI (H.hoist context state.child) state.input target
+      -- Subscribe to the child component's messages, writing them to the
       -- variable. Multiple writes without a take will queue messages.
       H.liftAff $ io.subscribe
         $ consumer \msg -> do
@@ -134,7 +176,7 @@ component =
 
   -- We don't need to render anything; this component is explicitly meant to be
   -- passed through.
-  render :: State query input output -> H.ComponentHTML output () m
+  render :: State n query input output -> H.ComponentHTML output () m
   render _ = HH.text ""
 
   -- This is needed for a hint to the typechecker. Without it there's an


### PR DESCRIPTION
I hope this is clear enough: it takes the parent monad `m` and lets the user provide a function `n ~> Aff` to contextualize the child into `Aff`. Which basically means it works for `Aff` and `ReaderT` now (and I provided convenience functions for that purpose).

(Easier to just PR the changes than try to explain it over chat ^.^.)

`NT` is provided as a newtype because of impredicativity. My usual tricks didn't seem to work, even to get a function like `pure identity :: Aff (Aff ~> Aff)` to typecheck.