### PR TITLE
PortalM type class - to avoid having to specify contextualise function

### DIFF
--- a/spago.dhall
+++ b/spago.dhall
@@ -7,6 +7,7 @@
   , "foldable-traversable"
   , "free"
   , "halogen"
+  , "halogen-store"
   , "halogen-subscriptions"
   , "maybe"
   , "prelude"

--- a/spago.example.dhall
+++ b/spago.example.dhall
@@ -7,6 +7,7 @@
   , "foldable-traversable"
   , "free"
   , "halogen"
+  , "halogen-store"
   , "halogen-storybook"
   , "halogen-subscriptions"
   , "maybe"


### PR DESCRIPTION
This PR adds a `PortalM` typeclass. If a function is constrained with this typeclass, then it is possible to use the `portalM` function, to avoid having to provide a `m (n ~> Aff)` function explicitly.
This is just a helper we are using to simplify usage.

Credit to @roryc89

NB: my editor automatically `purs-tidy`s files on save. I have added a prior commit that simply runs `purs-tidy` so to see actual changes made, see [820b3b7](https://github.com/thomashoneyman/purescript-halogen-portal/pull/10/commits/820b3b70a5508242eb957b7559d6828543f2eb41)