### PR TITLE
Yaml files for spago@next

### DIFF
--- a/spago.example.yaml
+++ b/spago.example.yaml
@@ -1,0 +1,23 @@
+package:
+  dependencies:
+  - aff
+  - avar
+  - console
+  - effect
+  - foldable-traversable
+  - free
+  - halogen
+  - halogen-store
+  - halogen-storybook
+  - halogen-subscriptions
+  - maybe
+  - prelude
+  - tailrec
+  - transformers
+  - typelevel-prelude
+  - web-html
+  name: halogen-portal
+workspace:
+  extra_packages: {}
+  package_set:
+    url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.7-20230207/packages.json

--- a/spago.yaml
+++ b/spago.yaml
@@ -1,0 +1,19 @@
+package:
+  dependencies:
+  - aff
+  - console
+  - effect
+  - foldable-traversable
+  - free
+  - halogen
+  - halogen-store
+  - maybe
+  - prelude
+  - transformers
+  - typelevel-prelude
+  - web-html
+  name: halogen-portal
+workspace:
+  extra_packages: {}
+  package_set:
+    url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.7-20230207/packages.json


### PR DESCRIPTION
The next version of spago can not use repositories with old configuration file format when they have been specified under `extra_packages`. See also https://github.com/purescript/spago/issues/1149